### PR TITLE
APIからのレスポンスをutf8.decode()で明示的にUTF-8文字列に変換して取得する

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1420;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/repository/trash_api.dart
+++ b/lib/repository/trash_api.dart
@@ -32,12 +32,12 @@ class TrashApi implements TrashApiInterface {
     Uri endpointUri = Uri.parse("${this._mobileApiEndpoint}/register");
     http.Response response = await this._httpClient.post(
         endpointUri,
-        headers: {"Content-Type": "application/json"},
+        headers: {"content-type": "application/json;charset=utf-8"},
         body: json.encode({"platform": _platform})
     );
 
     if(response.statusCode == 200) {
-      Map<String,dynamic> body = jsonDecode(response.body);
+      Map<String,dynamic> body = jsonDecode(utf8.decode(response.bodyBytes));
       _logger.d("Success register: " + body.toString());
       return body.containsKey("id") && body.containsKey("timestamp") ? RegisterResponse(body["id"] as String, body["timestamp"] as int) : null;
     }
@@ -51,12 +51,12 @@ class TrashApi implements TrashApiInterface {
     Uri endpointUri = Uri.parse("${this._mobileApiEndpoint}/update");
     http.Response response = await this._httpClient.post(
         endpointUri,
-        headers: {"Content-Type": "application/json"},
+        headers: {"content-type": "application/json;charset=utf-8", "Accept": "application/json"},
         body: json.encode({"id": id, "description": jsonEncode(localSchedule), "platform": _platform, "timestamp": timestamp})
     );
 
     if(response.statusCode == 200) {
-      Map<String,dynamic> body = jsonDecode(response.body);
+      Map<String,dynamic> body = jsonDecode(utf8.decode(response.bodyBytes));
       _logger.d("Success update: " + body.toString());
       return body.containsKey("timestamp") ? TrashUpdateResult(body["timestamp"] as int, UpdateResult.SUCCESS) : TrashUpdateResult(-1, UpdateResult.ERROR);
     } else if(response.statusCode == 400) {
@@ -70,12 +70,11 @@ class TrashApi implements TrashApiInterface {
   @override
   Future<TrashSyncResult> syncTrashData(String userId) async {
     Uri endpointUri = Uri.parse("${this._mobileApiEndpoint}/sync?user_id=$userId");
-    http.Response response = await this._httpClient.get(endpointUri);
+    http.Response response = await this._httpClient.get(endpointUri, headers: {"content-type":"text/html;charset=utf8","Accept": "application/json"});
     if(response.statusCode == 200) {
-      _logger.d(response.body);
       try {
         TrashApiSyncDataResponse trashResponse = TrashApiSyncDataResponse.fromJson(
-            jsonDecode(response.body));
+            jsonDecode(utf8.decode(response.bodyBytes)));
         _logger.d(trashResponse.description);
         List<TrashData> trashDataList = (jsonDecode(
             trashResponse.description) as List<dynamic>).map<TrashData>((

--- a/test/unit/repository/trash_api_test.dart
+++ b/test/unit/repository/trash_api_test.dart
@@ -190,8 +190,9 @@ void main() {
             '{\\"id\\":\\"1\\",\\"type\\":\\"burn\\",\\"trash_val\\":\\"\\",\\"schedules\\":[{\\"type\\":\\"weekday\\",\\"value\\":\\"0\\"}],\\"excludes\\":[]},'
             '{\\"id\\":\\"2\\",\\"type\\":\\"unburn\\",\\"schedules\\":[{\\"type\\":\\"month\\",\\"value\\":3}],\\"excludes\\":[]},'
             '{\\"id\\":\\"3\\",\\"type\\":\\"bottole\\",\\"schedules\\":[{\\"type\\":\\"biweek\\",\\"value\\":\\"3-2\\"}],\\"excludes\\":[]},'
-            '{\\"id\\":\\"4\\",\\"type\\":\\"other\\",\\"trash_val\\":\\"test_trash_id\\",\\"schedules\\":[{\\"type\\":\\"evweek\\",\\"value\\":{\\"interval\\":2,\\"weekday\\":\\"0\\"}}],\\"excludes\\":[]}'
-            ']", "timestamp": 12345678, "platform": "ios"}', 200);
+            '{\\"id\\":\\"4\\",\\"type\\":\\"other\\",\\"trash_val\\":\\"test_trash_id\\",\\"schedules\\":[{\\"type\\":\\"evweek\\",\\"value\\":{\\"interval\\":2,\\"weekday\\":\\"0\\"}}],\\"excludes\\":[]},'
+            '{\\"id\\":\\"5\\",\\"type\\":\\"other\\",\\"trash_val\\":\\"日本語の名前\\",\\"schedules\\":[{\\"type\\":\\"evweek\\",\\"value\\":{\\"interval\\":2,\\"weekday\\":\\"0\\"}}],\\"excludes\\":[]}'
+            ']", "timestamp": 12345678, "platform": "ios"}',  200,headers: {"content-type": "application/json;charset=utf-8"});
       });
 
       TrashApiInterface trashApi = TrashApi("https://example.com", mockClient);
@@ -199,7 +200,7 @@ void main() {
       expect(result, isNotNull);
       expect(result.timestamp, 12345678);
       expect(result.syncResult, TrashApiSyncStatus.SUCCESS);
-      expect(result.allTrashDataList.length, 4);
+      expect(result.allTrashDataList.length, 5);
       expect(result.allTrashDataList[0].id, "1");
       expect(result.allTrashDataList[0].type, "burn");
       expect(result.allTrashDataList[0].trashVal, "");
@@ -229,6 +230,14 @@ void main() {
       expect(result.allTrashDataList[3].schedules[0].value["interval"], 2);
       expect(result.allTrashDataList[3].schedules[0].value["weekday"], "0");
       expect(result.allTrashDataList[3].excludes.length, 0);
+      expect(result.allTrashDataList[4].id, "5");
+      expect(result.allTrashDataList[4].type, "other");
+      expect(result.allTrashDataList[4].trashVal, "日本語の名前");
+      expect(result.allTrashDataList[4].schedules.length, 1);
+      expect(result.allTrashDataList[4].schedules[0].type, "evweek");
+      expect(result.allTrashDataList[4].schedules[0].value["interval"], 2);
+      expect(result.allTrashDataList[4].schedules[0].value["weekday"], "0");
+      expect(result.allTrashDataList[4].excludes.length, 0);
     });
     test(
         "syncTrashDataでレスポンスのステータスコードが200以外の場合、TrashSyncResultのallTrashDataListが空、タイムスタンプが-1、SyncResultがERRORであること", () async {


### PR DESCRIPTION
- APIレスポンスヘッダにcharsetの明示がないがUTF-8文字列でレスポンスは返っている
- このためFlutter上でLatin-1と判断されresponse.bodyにデコードされている