### PR TITLE
LWAでアカウントリンクが行えない不具合の修正

### DIFF
--- a/json/development/config.json
+++ b/json/development/config.json
@@ -1,6 +1,6 @@
 {
-  "mobileApiEndpoint": "https://mobile.mythrowaway.net/dev",
-  "apiEndpoint": "https://backend.mythrowaway.net/dev",
-  "apiErrorUrl": "https://backend.mythrowaway.net/dev/500.html",
+  "mobileApiEndpoint": "https://dev.mobile.mythrowaway.net/dev",
+  "apiEndpoint": "https://dev.backend.mythrowaway.net/dev",
+  "apiErrorUrl": "https://dev.backend.mythrowaway.net/dev/500.html",
   "alarmApiUrl": "https://ogenzfkwt2.execute-api.ap-northeast-1.amazonaws.com/dev"
 }


### PR DESCRIPTION
- Androidアプリの不具合改修のためログイン後のリダイレクトURIが変更されており、iOSアプリ側でのリダイレクト先変更処理でマッチしていないことが原因。
- 開発環境のAPIエンドポイントが変更される予定のため先行して変更